### PR TITLE
Updating configuration loader.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs"
+
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ npm install eureka-js-client --save
 ```
 
 ### Add Eureka client to a Node application.
-Note: If the configuration object is not passed to the constuctor, the module will look for configuration file named `eureka-client-config.js` in the current working directory.
+
+The Eureka module exports a JavaScript function that can be constructed.
 
 ```javascript
 var Eureka = require('eureka-js-client');
@@ -37,6 +38,11 @@ var client = new Eureka({
   }
 });
 ```
+
+If the configuration object is not passed to the constructor, the module will look for a YAML configuration file.
+
+By default, Eureka client searches for the YAML file `eureka-client.yml` in the current working directory. It further searches for environment specific overrides in the environment specific YAML files. The environment is typically `test` or `production`, and is determined by the `NODE_ENV` environment variable.
+
 
 ### Get Instances By AppId
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ gulp.task('lint', function() {
     .pipe(eslint.failOnError());
 });
 
-gulp.task('test', function () {
+gulp.task('mocha', function () {
   return gulp.src('test/**/*.test.js', {read: false})
     .pipe(mocha({
       reporter: 'spec',
@@ -26,6 +26,8 @@ gulp.task('test', function () {
       }
     }));
 });
+
+gulp.task('test', ['lint', 'mocha']);
 
 gulp.task('test:watch', function() {
   return gulp.watch(['src/**/*.js', 'test/**/*.test.js'], ['test']);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/eureka-client.js",
   "scripts": {
     "prepublish": "gulp",
-    "test": "gulp test"
+    "test": "gulp test",
+    "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "babel": "^5.8.21",
     "chai": "^3.2.0",
+    "coveralls": "^2.11.4",
     "eslint": "^1.2.0",
     "eslint-config-xo": "^0.3.1",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/jquatier/eureka-js-client",
   "dependencies": {
+    "deepmerge": "^0.2.10",
+    "js-yaml": "^3.3.1",
     "request": "^2.60.0"
   },
   "devDependencies": {

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -1,4 +1,8 @@
 import request from 'request';
+import fs from 'fs';
+import yaml from 'js-yaml';
+import merge from 'deepmerge';
+import path from 'path';
 
 /*
   Eureka JS client
@@ -13,7 +17,21 @@ export default class Eureka {
     console.log('initializing eureka client');
     this.config = config;
     if (!config) {
-      this.config = require(process.cwd() + '/eureka-client-config.js');
+      // Load up the current working directory and the environment:
+      const cwd = process.cwd();
+      const env = process.env.NODE_ENV || 'development';
+
+      // Attempt to load the config file:
+      try {
+        config = yaml.safeLoad(fs.readFileSync(path.join(cwd, 'eureka-client.yml'), 'utf8'));
+      } catch(e) {}
+
+      try {
+        const envConfig = yaml.safeLoad(fs.readFileSync(path.join(cwd, `eureka-client-${env}.yml`), 'utf8'));
+        config = merge(config, envConfig);
+      }catch(e) {}
+
+      this.config = config;
     }
     if (!this.config) {
       throw new Error('missing configuration file.');

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -29,7 +29,7 @@ export default class Eureka {
       try {
         const envConfig = yaml.safeLoad(fs.readFileSync(path.join(cwd, `eureka-client-${env}.yml`), 'utf8'));
         config = merge(config, envConfig);
-      }catch(e) {}
+      } catch(e) {}
 
       this.config = config;
     }

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -7,8 +7,7 @@ import path from 'path';
 /*
   Eureka JS client
   This module handles registration with a Eureka server, as well as heartbeats 
-  for reporting instance health. This module requires a eureka-client-config.js configuration
-  file.
+  for reporting instance health.
 */
 
 export default class Eureka {


### PR DESCRIPTION
Using YAML configuration loader based on mechanics that align more with the Netflix OSS eureka configuration loader. Support environment-based overrides.
Enforcing lint passes when running tests.

For context, I decided to use YAML over JSON because it is a little bit more like `.properties` files, and supports some really nice things like comments that JSON files don't support. Plus, it's a true markup format unlike JS, where arbitrary code could be run in a config (probably not good).