### PR TITLE
Callbacks & Loggers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": "xo/esnext",
   "rules": {
     "indent": [2, 2],
-    "no-trailing-spaces": 0
+    "no-trailing-spaces": 0,
+    "prefer-reflect": 0
   },
   "env": {
     "mocha": true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/jquatier/eureka-js-client",
   "dependencies": {
+    "async": "^1.4.2",
     "deepmerge": "^0.2.10",
     "js-yaml": "^3.3.1",
     "request": "^2.60.0"

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,0 +1,44 @@
+
+const LEVELS = {
+  error: 50,
+  warn: 40,
+  info: 30,
+  debug: 20
+};
+const DEFAULT_LEVEL = LEVELS.info;
+
+export class Logger {
+  constructor() {
+    this._level = 10;
+  }
+
+  level(val) {
+    if (val) {
+      if (typeof val === 'string') {
+        val = LEVELS[val];
+      }
+      this._level = val || DEFAULT_LEVEL;
+    }
+    return this._level;
+  }
+
+  // Abstract the console call:
+  _log(method, args) {
+    if (this._level >= LEVELS[method]) {
+      console[method](...args);
+    }
+  }
+
+  error() {
+    return this._log('error', arguments);
+  }
+  warn() {
+    return this._log('ward', arguments);
+  }
+  info() {
+    return this._log('info', arguments);
+  }
+  debug() {
+    return this._log('log', arguments);
+  }
+}

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -33,7 +33,7 @@ export class Logger {
     return this._log('error', arguments);
   }
   warn() {
-    return this._log('ward', arguments);
+    return this._log('warn', arguments);
   }
   info() {
     return this._log('info', arguments);

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -7,8 +7,6 @@ import {parallel} from 'async';
 
 import {Logger} from './Logger.js';
 
-const logger = new Logger();
-
 const noop = () => {};
 
 /*
@@ -29,7 +27,7 @@ export class Eureka {
 
   constructor(config) {
     // Allow passing in a custom logger:
-    this.logger = logger || config.logger;
+    this.logger = config.logger || new Logger();
 
     this.logger.debug('initializing eureka client');
 

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -1,0 +1,1 @@
+import {Logger} from '../src/Logger.js';

--- a/test/eureka-client.test.js
+++ b/test/eureka-client.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import {expect} from 'chai';
-import Eureka from '../src/eureka-client';
+import {Eureka} from '../src/eureka-client';
 
 describe('eureka client', () => {
   describe('Eureka()', () => {
@@ -12,9 +12,6 @@ describe('eureka client', () => {
     });
 
     it('should construct with the correct configuration values', () => {
-      const registerStub = sinon.stub(Eureka.prototype, 'register');
-      const fetchStub = sinon.stub(Eureka.prototype, 'fetchRegistry'); 
-
       function shouldThrow() {
         return new Eureka();
       }
@@ -49,9 +46,6 @@ describe('eureka client', () => {
       expect(shouldThrow).to.throw();
       expect(noApp).to.throw(/app/);
       expect(shouldWork).to.not.throw();
-
-      registerStub.restore();
-      fetchStub.restore();
     });
   });
 });


### PR DESCRIPTION
So this PR covers a few things:

1.) Included new logger class. Overwriting the logger can be done by passing a logger param into the config object.
2.) Moved Eureka to a named export.
3.) Added callbacks to all async functions. Callbacks follow node style. If no callback is passed it defaults to a noop.
4.) No longer calling register and fetchRegistry out of the constructor.
5.) New start method that will run the register and the fetchRegistry in parallel and fire the callback when it is complete.