### PR TITLE
Making service path configurable

### DIFF
--- a/src/default-config.js
+++ b/src/default-config.js
@@ -3,7 +3,8 @@
 export default {
   eureka: {
     heartbeatInterval: 30000,
-    registryFetchInterval: 30000
+    registryFetchInterval: 30000,
+    servicePath: '/eureka/v2/apps/'
   },
   instance: {}
 };

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -20,7 +20,7 @@ function getYaml(file) {
   let yml = {};
   try {
     yml = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
-  } catch(e) {}
+  } catch (e) {}
   return yml;
 }
 

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -56,7 +56,7 @@ export class Eureka {
     Base Eureka server URL + path
   */
   get eurekaUrl() {
-    return `http://${this.config.eureka.host}:${this.config.eureka.port}/eureka/v2/apps/`;
+    return `http://${this.config.eureka.host}:${this.config.eureka.port}${this.config.eureka.servicePath}`;
   }
 
   /*


### PR DESCRIPTION
Fixes #26. Allowing module users to set a different service path for eureka. The configuration will still default to the /eureka/v2/apps path, which will work for most installations, including Docker users.