### PR TITLE
Adding custom filename and cwd configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,24 @@ var client = new Eureka({
 });
 ```
 
-The Eureka client searches for the YAML file `eureka-client.yml` in the current working directory. It further searches for environment specific overrides in the environment specific YAML files. The environment is typically `test` or `production`, and is determined by the `NODE_ENV` environment variable.
+The Eureka client searches for the YAML file `eureka-client.yml` in the current working directory. It further searches for environment specific overrides in the environment specific YAML files (e.g. `eureka-client-test.yml`). The environment is typically `development` or `production`, and is determined by the `NODE_ENV` environment variable. The options passed to the constructor overwrite any values that are set in configuration files.
 
-The options passed to the constructor overwrite any values that are set in configuration files.
+You can configure a custom directory to load the configuration files from by specifying a `cwd` option in the object passed to the `Eureka` constructor.
+
+```javascript
+var client = new Eureka({
+  cwd: __dirname + '/config'
+});
+```
+
+If you wish, you can also overwrite the name of the file that is loaded with the `filename` property. However, this disables the environment-based configuration loaded. You can mix the `cwd` and `filename` options.
+
+```javascript
+var client = new Eureka({
+  filename: 'eureka.yml',
+  cwd: __dirname + '/config'
+});
+```
 
 ### Register with Eureka & start application heartbeats
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var mocha = require('gulp-mocha');
 var eslint = require('gulp-eslint');
 var instrumenter = require('babel-istanbul').Instrumenter;
 var istanbul = require('gulp-istanbul');
+var env = require('gulp-env');
 var mochaBabel = require('babel/register');
 
 gulp.task('build', function() {
@@ -20,7 +21,12 @@ gulp.task('lint', function() {
 });
 
 gulp.task('mocha', function (cb) {
+  var envs = env.set({
+    NODE_ENV: 'test'
+  });
+
   gulp.src('src/**/*.js')
+    .pipe(envs)
     .pipe(istanbul({
       instrumenter: instrumenter
     })) // Covering files
@@ -28,8 +34,9 @@ gulp.task('mocha', function (cb) {
     .on('finish', function () {
       gulp.src(['test/**/*.js'])
         .pipe(mocha())
-        .pipe(istanbul.writeReports()) 
-        .pipe(istanbul.enforceThresholds({ thresholds: { global: 0 } })) 
+        .pipe(istanbul.writeReports())
+        .pipe(istanbul.enforceThresholds({ thresholds: { global: 0 } }))
+        .pipe(envs.reset)
         .on('end', cb);
     });
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-xo": "^0.3.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.0",
+    "gulp-env": "^0.4.0",
     "gulp-eslint": "^1.0.0",
     "gulp-istanbul": "^0.10.0",
     "gulp-mocha": "^2.1.3",

--- a/src/eureka-client.js
+++ b/src/eureka-client.js
@@ -28,19 +28,23 @@ function getYaml(file) {
 
 export class Eureka {
 
-  constructor(config) {
+  constructor(config = {}) {
     // Allow passing in a custom logger:
     this.logger = config.logger || new Logger();
 
     this.logger.debug('initializing eureka client');
 
     // Load up the current working directory and the environment:
-    const cwd = process.cwd();
+    const cwd = config.cwd || process.cwd();
     const env = process.env.NODE_ENV || 'development';
 
     // Load in the configuration files:
-    this.config = merge(defaultConfig, getYaml(path.join(cwd, 'eureka-client.yml')));
-    this.config = merge(this.config, getYaml(path.join(cwd, `eureka-client-${env}.yml`)));
+    if (config.filename) {
+      this.config = merge(defaultConfig, getYaml(path.join(cwd, config.filename)));
+    } else {
+      this.config = merge(defaultConfig, getYaml(path.join(cwd, 'eureka-client.yml')));
+      this.config = merge(this.config, getYaml(path.join(cwd, `eureka-client-${env}.yml`)));
+    }
 
     // Finally, merge in the passed configuration:
     this.config = merge(this.config, config);

--- a/test/eureka-client-test.yml
+++ b/test/eureka-client-test.yml
@@ -1,0 +1,3 @@
+eureka:
+  overrides: 2
+  otherCustom: 'test2'

--- a/test/eureka-client.yml
+++ b/test/eureka-client.yml
@@ -1,0 +1,11 @@
+eureka:
+  overrides: 1
+  custom: 'test'
+  heartbeatInterval: 999
+  registryFetchInterval: 999
+  fetchRegistry: false
+  servicePath: '/eureka/v2/apps/'
+  ssl: false
+  useDns: false
+  fetchMetadata: false
+instance: {}

--- a/test/fixtures/config.yml
+++ b/test/fixtures/config.yml
@@ -1,0 +1,2 @@
+eureka:
+  fromFixture: true


### PR DESCRIPTION
This adds two options to the constructor, `cwd` and `filename`, which let you configure the files that eureka-js-client uses for configuration.

This PR also adds the corresponding tests for loading the files.