### PR TITLE
Registry enhancements

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -256,7 +256,7 @@ export default class Eureka {
     }
     const instances = this.cache.app[appId.toUpperCase()];
     if (!instances) {
-      this.logger.debug(`Unable to retrieve instances for appId: ${appId}`);
+      this.logger.warn(`Unable to retrieve instances for appId: ${appId}`);
     }
     return instances;
   }
@@ -270,7 +270,7 @@ export default class Eureka {
     }
     const instances = this.cache.vip[vipAddress];
     if (!instances) {
-      this.logger.debug(`Unable to retrieves instances for vipAddress: ${vipAddress}`);
+      this.logger.warn(`Unable to retrieves instances for vipAddress: ${vipAddress}`);
     }
     return instances;
   }

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -305,15 +305,14 @@ export default class Eureka {
     if (!registry) {
       this.logger.warn('Unable to transform empty registry');
     } else {
-      const newCache = { app: {}, vip: {} };
       if (!registry.applications.application) {
         return;
       }
+      const newCache = { app: {}, vip: {} };
       if (registry.applications.application.length) {
-        for (let i = 0; i < registry.applications.application.length; i++) {
-          const app = registry.applications.application[i];
+        registry.applications.application.forEach((app) => {
           this.transformApp(app, newCache);
-        }
+        });
       } else {
         this.transformApp(registry.applications.application, newCache);
       }

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -309,7 +309,7 @@ export default class Eureka {
         return;
       }
       const newCache = { app: {}, vip: {} };
-      if (registry.applications.application.length) {
+      if (Array.isArray(registry.applications.application)) {
         registry.applications.application.forEach((app) => {
           this.transformApp(app, newCache);
         });


### PR DESCRIPTION
2 things:

1. We used to throw an error if there were no applications/instances found for a vip/app, which seems a bit aggressive and means anyone calling those accessors would have to catch the exception. I think it would be better to just return undefined in those cases.

2. We were wiping out the registry cache before we had populated a new one, which could lead to a timing issue if someone was accessing the registry while it was refreshing. With this PR, we don't modify the cache until we have a new one ready-to-go.