### PR TITLE
Added config option to use local AWS metadata info instead of public …

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -8,6 +8,7 @@ export default {
     ssl: false,
     useDns: false,
     fetchMetadata: true,
+    useLocalMetadata: false,
   },
   instance: {},
 };


### PR DESCRIPTION
…hostname and IP

Fixes #46 (Optionally use local IP when deployed in AWS))