### PR TITLE
V3 Release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
 ## 3.0.0
+  - Added support for the following events: `started`, `registered`, `deregistered`, `heartbeat`, and `registryUpdated`.
   - Improved the stability of the client when it encounters downstream DNS errors, as a side-effect the callback for `fetchRegistries()` now returns errors when they are encountered.
   - Populate registry cache with instances that have a status of `UP`, `filterUpInstances` can be set to `false` to disable.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,2 @@
+## 3.0.0
+  - Populate registry cache with instances that have a status of `UP`, `filterUpInstances` can be set to `false` to disable.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## 3.0.0
+  - Added better exception handling around malformed YAML configuration files.
   - Added support for the following events: `started`, `registered`, `deregistered`, `heartbeat`, and `registryUpdated`.
   - Improved the stability of the client when it encounters downstream DNS errors, as a side-effect the callback for `fetchRegistries()` now returns errors when they are encountered.
   - Populate registry cache with instances that have a status of `UP`, `filterUpInstances` can be set to `false` to disable.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,3 @@
 ## 3.0.0
+  - Improved the stability of the client when it encounters downstream DNS errors, as a side-effect the callback for `fetchRegistries()` now returns errors when they are encountered.
   - Populate registry cache with instances that have a status of `UP`, `filterUpInstances` can be set to `false` to disable.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ If your have multiple availability zones and your DNS entries set up according t
 
 This will cause the client to perform a DNS lookup using `config.eureka.host` and `config.eureka.ec2Region`. The naming convention for the DNS TXT records required for this to function is also described in the Wiki article above.
 
+## Configuration Options
+option | default value | description
+---- | --- | ---
+`logger` | console logging | logger implementation for the client to use
+`eureka.heartbeatInterval` | `30000` | milliseconds to wait between heartbeats
+`eureka.registryFetchInterval` | `30000` | milliseconds to wait between registry fetches
+`eureka.fetchRegistry` | `true` | enable/disable registry fetching
+`eureka.filterUpInstances` | `true` | enable/disable filtering of instances with status === `UP`
+`eureka.servicePath` | `/eureka/v2/apps/` | path to eureka REST service
+`eureka.ssl` | `false` | enable SSL communication with Eureka server
+`eureka.useDns` | `false` | look up Eureka server using DNS, see [Looking up Eureka Servers in AWS using DNS](#looking-up-eureka-servers-in-aws-using-dns)
+`eureka.fetchMetadata` | `true` | fetch AWS metadata when in AWS environment, see [Configuring for AWS environments](#configuring-for-aws-environments)
+`eureka.useLocalMetadata` | `false` | use local IP and local hostname from metadata when in an AWS environment.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ option | default value | description
 `eureka.fetchMetadata` | `true` | fetch AWS metadata when in AWS environment, see [Configuring for AWS environments](#configuring-for-aws-environments)
 `eureka.useLocalMetadata` | `false` | use local IP and local hostname from metadata when in an AWS environment.
 
+## Events
+
+Eureka client is an instance of `EventEmitter` and provides the following events for consumption:
+
+event | data provided | description
+---- | --- | ---
+`started` | N/A | Fired when eureka client is fully registered and all registries have been updated.
+`registered` | N/A | Fired when the eureka client is registered with eureka.
+`deregistered` | N/A | Fired when the eureka client is deregistered with eureka.
+`heartbeat` | N/A | Fired when the eureka client has successfully renewed it's lease with eureka.
+`registryUpdated` | N/A | Fired when the eureka client has successfully update it's registries.
+
 ## Debugging
 
 The library uses [request](https://github.com/request/request) for all service calls, and debugging can be turned on by passing `NODE_DEBUG=request` when you start node. This allows you you double-check the URL being called as well as other request properties.

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -120,14 +120,9 @@ export default class Eureka extends EventEmitter {
         if (this.config.eureka.fetchRegistry) {
           this.startRegistryFetches();
           if (this.config.eureka.waitForRegistry) {
-            const waitForRegistryUpdate = (cb) => {
-              this.fetchRegistry(() => {
-                const found = this.getInstancesByVipAddress(this.config.instance.vipAddress);
-                if (!found) setTimeout(() => waitForRegistryUpdate(cb), 2000);
-                else cb();
-              });
-            };
-            return waitForRegistryUpdate(done);
+            this.on('registryUpdated', () => {
+              done();
+            });
           }
           this.fetchRegistry(done);
         } else {

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -120,9 +120,14 @@ export default class Eureka extends EventEmitter {
         if (this.config.eureka.fetchRegistry) {
           this.startRegistryFetches();
           if (this.config.eureka.waitForRegistry) {
-            this.on('registryUpdated', () => {
-              done();
-            });
+            const waitForRegistryUpdate = (cb) => {
+              this.fetchRegistry(() => {
+                const found = this.getInstancesByVipAddress(this.config.instance.vipAddress);
+                if (!found) setTimeout(() => waitForRegistryUpdate(cb), 2000);
+                else cb();
+              });
+            };
+            return waitForRegistryUpdate(done);
           }
           this.fetchRegistry(done);
         } else {

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -356,17 +356,25 @@ export default class Eureka {
 
   /*
     Transforms the given application and places in client cache. If an application
-      has a single instance, the instance is placed into the cache as an array of one
+    has a single instance, the instance is placed into the cache as an array of one
    */
   transformApp(app, cache) {
     if (app.instance.length) {
-      cache.app[app.name.toUpperCase()] = app.instance;
-      cache.vip[app.instance[0].vipAddress] = app.instance;
-    } else {
+      const instances = app.instance.filter((instance) => (this.validateInstance(instance)));
+      cache.app[app.name.toUpperCase()] = instances;
+      cache.vip[app.instance[0].vipAddress] = instances;
+    } else if (this.validateInstance(app.instance)) {
       const instances = [app.instance];
       cache.vip[app.instance.vipAddress] = instances;
       cache.app[app.name.toUpperCase()] = instances;
     }
+  }
+
+  /*
+    Returns true if instance filtering is disabled, or if the instance is UP
+  */
+  validateInstance(instance) {
+    return (!this.config.eureka.filterUpInstances || instance.status === 'UP');
   }
 
   /*

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -19,12 +19,24 @@ function noop() {}
   for reporting instance health.
 */
 
+function fileExists(file) {
+  try {
+    return fs.statSync(file);
+  } catch (e) {
+    return false;
+  }
+}
+
 function getYaml(file) {
   let yml = {};
+  if (!fileExists(file)) {
+    return yml; // no configuration file
+  }
   try {
     yml = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
   } catch (e) {
-    // Ignore YAML load error.
+    // configuration file exists but was malformed
+    throw new Error(`Error loading YAML configuration file: ${file} ${e}`);
   }
   return yml;
 }
@@ -175,8 +187,8 @@ export default class Eureka extends EventEmitter {
     this.config.instance.status = 'UP';
     const connectionTimeout = setTimeout(() => {
       this.logger.warn('It looks like it\'s taking a while to register with ' +
-      'Eureka. This usually means there is an issue connecting to the host ' +
-      'specified. Start application with NODE_DEBUG=request for more logging.');
+        'Eureka. This usually means there is an issue connecting to the host ' +
+        'specified. Start application with NODE_DEBUG=request for more logging.');
     }, 10000);
     this.buildEurekaUrl((err, eurekaUrl) => {
       if (err) return callback(err);

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -467,7 +467,7 @@ export default class Eureka extends EventEmitter {
     }
     dns.resolveTxt(`txt.${ec2Region}.${host}`, (err, addresses) => {
       if (err) {
-        callback(new Error(
+        return callback(new Error(
           `Error resolving eureka server list for region [${ec2Region}] using DNS: [${err}]`
         ));
       }

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -4,6 +4,7 @@ export default {
     heartbeatInterval: 30000,
     registryFetchInterval: 30000,
     fetchRegistry: true,
+    filterUpInstances: true,
     servicePath: '/eureka/v2/apps/',
     ssl: false,
     useDns: false,

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -422,6 +422,25 @@ describe('Eureka client', () => {
       }));
       expect(client.config.eureka.fromFixture).to.equal(true);
     });
+
+    it('should throw error on malformed config file', () => {
+      function malformed() {
+        return new Eureka(makeConfig({
+          cwd: join(__dirname, 'fixtures'),
+          filename: 'malformed-config',
+        }));
+      }
+      expect(malformed).to.throw(Error);
+    });
+    it('should not throw error on malformed config file', () => {
+      function missingFile() {
+        return new Eureka(makeConfig({
+          cwd: join(__dirname, 'fixtures'),
+          filename: 'missing-config',
+        }));
+      }
+      expect(missingFile).to.not.throw();
+    });
   });
 
   describe('validateConfig()', () => {
@@ -699,7 +718,10 @@ describe('Eureka client', () => {
     let metadataSpy;
     beforeEach(() => {
       instanceConfig = {
-        app: 'app', vipAddress: '1.2.3.4', port: 9999, dataCenterInfo: { name: 'Amazon' },
+        app: 'app',
+        vipAddress: '1.2.3.4',
+        port: 9999,
+        dataCenterInfo: { name: 'Amazon' },
         statusPageUrl: 'http://__HOST__:8080/',
         healthCheckUrl: 'http://__HOST__:8077/healthcheck',
       };

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -142,6 +142,58 @@ describe('Eureka client', () => {
     });
   });
 
+  describe('startHeartbeats()', () => {
+    let config;
+    let client;
+    let renewSpy;
+    let clock;
+    before(() => {
+      config = makeConfig();
+      client = new Eureka(config);
+      renewSpy = sinon.stub(client, 'renew');
+      clock = sinon.useFakeTimers();
+    });
+
+    after(() => {
+      renewSpy.restore();
+      clock.restore();
+    });
+
+    it('should call renew on interval', () => {
+      client.startHeartbeats();
+      clock.tick(30000);
+      expect(renewSpy).to.have.been.calledOnce;
+      clock.tick(30000);
+      expect(renewSpy).to.have.been.calledTwice;
+    });
+  });
+
+  describe('startRegistryFetches()', () => {
+    let config;
+    let client;
+    let fetchRegistrySpy;
+    let clock;
+    before(() => {
+      config = makeConfig();
+      client = new Eureka(config);
+      fetchRegistrySpy = sinon.stub(client, 'fetchRegistry');
+      clock = sinon.useFakeTimers();
+    });
+
+    after(() => {
+      fetchRegistrySpy.restore();
+      clock.restore();
+    });
+
+    it('should call renew on interval', () => {
+      client.startRegistryFetches();
+      clock.tick(30000);
+      expect(fetchRegistrySpy).to.have.been.calledOnce;
+      clock.tick(30000);
+      expect(fetchRegistrySpy).to.have.been.calledTwice;
+    });
+  });
+
   describe('stop()', () => {
     let config;
     let client;
@@ -512,9 +564,9 @@ describe('Eureka client', () => {
       registry = {
         applications: { application: {} },
       };
-      instance1 = { host: '127.0.0.1', port: 1000, vipAddress: 'vip1' };
-      instance2 = { host: '127.0.0.2', port: 2000, vipAddress: 'vip2' };
-      instance3 = { host: '127.0.0.2', port: 2000, vipAddress: 'vip2' };
+      instance1 = { host: '127.0.0.1', port: 1000, vipAddress: 'vip1', status: 'UP' };
+      instance2 = { host: '127.0.0.2', port: 2000, vipAddress: 'vip2', status: 'UP' };
+      instance3 = { host: '127.0.0.2', port: 2000, vipAddress: 'vip2', status: 'UP' };
       app1 = { name: 'theapp', instance: instance1 };
       app2 = { name: 'theapptwo', instance: [instance2, instance3] };
       client = new Eureka(config);
@@ -548,6 +600,7 @@ describe('Eureka client', () => {
     let app;
     let instance1;
     let instance2;
+    let downInstance;
     let theVip;
     let cache;
     beforeEach(() => {
@@ -556,8 +609,9 @@ describe('Eureka client', () => {
       });
       client = new Eureka(config);
       theVip = 'theVip';
-      instance1 = { host: '127.0.0.1', port: 1000, vipAddress: theVip };
-      instance2 = { host: '127.0.0.2', port: 2000, vipAddress: theVip };
+      instance1 = { host: '127.0.0.1', port: 1000, vipAddress: theVip, status: 'UP' };
+      instance2 = { host: '127.0.0.2', port: 2000, vipAddress: theVip, status: 'UP' };
+      downInstance = { host: '127.0.0.2', port: 2000, vipAddress: theVip, status: 'DOWN' };
       app = { name: 'theapp' };
       cache = { app: {}, vip: {} };
     });
@@ -574,6 +628,25 @@ describe('Eureka client', () => {
       client.transformApp(app, cache);
       expect(cache.app[app.name.toUpperCase()].length).to.equal(2);
       expect(cache.vip[theVip].length).to.equal(2);
+    });
+
+    it('should filter UP instances by default', () => {
+      app.instance = [instance1, instance2, downInstance];
+      client.transformApp(app, cache);
+      expect(cache.app[app.name.toUpperCase()].length).to.equal(2);
+      expect(cache.vip[theVip].length).to.equal(2);
+    });
+
+    it('should not filter UP instances when filterUpInstances === false', () => {
+      config = makeConfig({
+        instance: { dataCenterInfo: { name: 'Amazon' } },
+        eureka: { filterUpInstances: false },
+      });
+      client = new Eureka(config);
+      app.instance = [instance1, instance2, downInstance];
+      client.transformApp(app, cache);
+      expect(cache.app[app.name.toUpperCase()].length).to.equal(3);
+      expect(cache.vip[theVip].length).to.equal(3);
     });
   });
 

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -639,6 +639,25 @@ describe('Eureka client', () => {
       expect(client.config.instance.healthCheckUrl).to.equal('http://fake-1:8077/healthcheck');
     });
   });
+  describe('buildEurekaUrl()', () => {
+    let config;
+    let client;
+
+    afterEach(() => {
+      dns.resolveTxt.restore();
+    });
+
+    it('should pass error when lookupCurrentEurekaHost passes error', () => {
+      config = makeConfig();
+      client = new Eureka(config);
+
+      sinon.stub(dns, 'resolveTxt').yields(null, []);
+      sinon.stub(client, 'lookupCurrentEurekaHost').yields(new Error());
+      const spy = sinon.spy();
+      client.buildEurekaUrl(spy);
+      expect(spy.args[0][0]).to.be.instanceof(Error);
+    });
+  });
 
   describe('locateEurekaHostUsingDns()', () => {
     let config;
@@ -653,15 +672,14 @@ describe('Eureka client', () => {
       dns.resolveTxt.restore();
     });
 
-    it('should throw error when ec2Region is undefined', () => {
+    it('should pass error when ec2Region is undefined', () => {
       config = makeConfig();
       client = new Eureka(config);
 
       sinon.stub(dns, 'resolveTxt').yields(null, []);
-      function noRegion() {
-        client.locateEurekaHostUsingDns();
-      }
-      expect(noRegion).to.throw(Error);
+      const spy = sinon.spy();
+      client.locateEurekaHostUsingDns(spy);
+      expect(spy.args[0][0]).to.be.instanceof(Error);
     });
 
     it('should lookup server list using DNS', () => {
@@ -680,7 +698,7 @@ describe('Eureka client', () => {
       expect(dns.resolveTxt).to.have.been.calledWith(
         sinon.match(value => eurekaHosts.indexOf(value))
       );
-      expect(locateCb).to.have.been.calledWithMatch('1.2.3.4');
+      expect(locateCb).to.have.been.calledWithMatch(null, '1.2.3.4');
     });
   });
 });

--- a/test/fixtures/malformed-config.yml
+++ b/test/fixtures/malformed-config.yml
@@ -1,0 +1,3 @@
+eureka:
+  fromFixture: true
+  @something: false


### PR DESCRIPTION
This release has a couple bugfixes, some improvements to usability, and some new features. Unit tests have also been added and improved. 

Changes:
  - Added better exception handling around malformed YAML configuration files. 
  - Added support for the following events: `started`, `registered`, `deregistered`, `heartbeat`, and `registryUpdated`. 
  - Improved the stability of the client when it encounters downstream DNS errors, as a side-effect the callback for `fetchRegistries()` now returns errors when they are encountered.
  - Populate registry cache with instances that have a status of `UP`, `filterUpInstances` can be set to `false` to disable. See #48 for original issue.

The main benefit of this release is the improved exception handling around DNS errors in AWS environments. Currently, if a DNS query were to fail (which is likely in a network outage) the client would throw an uncaught exception. The instance would most likely not recover when the network was available again (heartbeats stop). In V3, these errors are properly caught so that heartbeats continue to execute on interval. This scenario was simulated today and V3 resolves the issue completely.