### PR TITLE
Allow DNS lookups even if not using Amazon

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -443,7 +443,7 @@ export default class Eureka extends EventEmitter {
     execute DNS lookups which is an async network operation.
   */
   lookupCurrentEurekaHost(callback = noop) {
-    if (this.amazonDataCenter && this.config.eureka.useDns) {
+    if (this.config.eureka.useDns) {
       this.locateEurekaHostUsingDns((err, resolvedHost) => callback(err, resolvedHost));
     } else {
       return callback(null, this.config.eureka.host);


### PR DESCRIPTION
It's possible to configure Eureka outside of Amazon datacenters but still use DNS lookups as long as the region and hostnames are set up properly.