### PR TITLE
 Always return an array from `getInstancesByAppId`

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -304,7 +304,7 @@ export default class Eureka extends EventEmitter {
       throw new RangeError('Unable to query instances with no appId');
     }
     const instances = this.cache.app[appId.toUpperCase()] || [];
-    if (!instances) {
+    if (instances.length === 0) {
       this.logger.warn(`Unable to retrieve instances for appId: ${appId}`);
     }
     return instances;
@@ -318,7 +318,7 @@ export default class Eureka extends EventEmitter {
       throw new RangeError('Unable to query instances with no vipAddress');
     }
     const instances = this.cache.vip[vipAddress] || [];
-    if (!instances) {
+    if (instances.length === 0) {
       this.logger.warn(`Unable to retrieves instances for vipAddress: ${vipAddress}`);
     }
     return instances;

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -303,10 +303,9 @@ export default class Eureka extends EventEmitter {
     if (!appId) {
       throw new RangeError('Unable to query instances with no appId');
     }
-    const instances = this.cache.app[appId.toUpperCase()];
+    const instances = this.cache.app[appId.toUpperCase()] || [];
     if (!instances) {
       this.logger.warn(`Unable to retrieve instances for appId: ${appId}`);
-      instances = [];
     }
     return instances;
   }

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -134,8 +134,8 @@ export default class Eureka extends EventEmitter {
           if (this.config.eureka.waitForRegistry) {
             const waitForRegistryUpdate = (cb) => {
               this.fetchRegistry(() => {
-                const found = this.getInstancesByVipAddress(this.config.instance.vipAddress);
-                if (!found) setTimeout(() => waitForRegistryUpdate(cb), 2000);
+                const instances = this.getInstancesByVipAddress(this.config.instance.vipAddress);
+                if (instances.length === 0) setTimeout(() => waitForRegistryUpdate(cb), 2000);
                 else cb();
               });
             };

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -306,6 +306,7 @@ export default class Eureka extends EventEmitter {
     const instances = this.cache.app[appId.toUpperCase()];
     if (!instances) {
       this.logger.warn(`Unable to retrieve instances for appId: ${appId}`);
+      instances = [];
     }
     return instances;
   }

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -317,7 +317,7 @@ export default class Eureka extends EventEmitter {
     if (!vipAddress) {
       throw new RangeError('Unable to query instances with no vipAddress');
     }
-    const instances = this.cache.vip[vipAddress];
+    const instances = this.cache.vip[vipAddress] || [];
     if (!instances) {
       this.logger.warn(`Unable to retrieves instances for vipAddress: ${vipAddress}`);
     }

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -523,8 +523,8 @@ describe('Eureka client', () => {
       expect(actualInstances).to.equal(expectedInstances);
     });
 
-    it('should return undefined no instances were found for given appId', () => {
-      expect(client.getInstancesByAppId('THESERVICENAME')).to.equal(undefined);
+    it('should return empty array if no instances were found for given appId', () => {
+      expect(client.getInstancesByAppId('THESERVICENAME')).to.deep.equal([]);
     });
   });
 
@@ -551,8 +551,8 @@ describe('Eureka client', () => {
       expect(actualInstances).to.equal(expectedInstances);
     });
 
-    it('should return undefined no instances were found for given vipAddress', () => {
-      expect(client.getInstancesByVipAddress('the.vip.address')).to.equal(undefined);
+    it('should return empty array if no instances were found for given vipAddress', () => {
+      expect(client.getInstancesByVipAddress('the.vip.address')).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
It makes sense to return an array all the time as it allows
consumers to do stuff like `client.getInstancesByAppId('id').map(...).filter(...)`
without error checking first.

Error checking can still be done by checking `instances.length !== 0`.