### PR TITLE
JSON parse exception handling

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -339,7 +339,11 @@ export default class Eureka extends EventEmitter {
       }, (error, response, body) => {
         if (!error && response.statusCode === 200) {
           this.logger.debug('retrieved registry successfully');
-          this.transformRegistry(JSON.parse(body));
+          try {
+            this.transformRegistry(JSON.parse(body));
+          } catch (ex) {
+            return callback(ex);
+          }
           this.emit('registryUpdated');
           return callback(null);
         } else if (error) {

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -614,7 +614,7 @@ describe('Eureka client', () => {
       const registryCb = sinon.spy();
       client.fetchRegistry(registryCb);
 
-      expect(registryCb).to.have.been.calledWithMatch({ message: 'Unexpected token b' });
+      expect(registryCb).to.have.been.calledWith(new SyntaxError());
     });
   });
 

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -608,6 +608,14 @@ describe('Eureka client', () => {
 
       expect(registryCb).to.have.been.calledWithMatch({ message: 'request error' });
     });
+
+    it('should throw error on invalid JSON', () => {
+      sinon.stub(request, 'get').yields(null, { statusCode: 200 }, '{ blah');
+      const registryCb = sinon.spy();
+      client.fetchRegistry(registryCb);
+
+      expect(registryCb).to.have.been.calledWithMatch({ message: 'Unexpected token b' });
+    });
   });
 
   describe('transformRegistry()', () => {


### PR DESCRIPTION
In the edge case where missing or bad JSON is returned from the server, we can make the client a little more resilient and return a better error. Right now an uncaught exception is thrown. We already check for a 200 status, but it could still happen (and this did get reported to me over email).