### PR TITLE
correctly merges dataCenterInfo.metadata. fixes #144

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -528,8 +528,8 @@ export default class Eureka extends EventEmitter {
   addInstanceMetadata(callback = noop) {
     this.metadataClient.fetchMetadata(metadataResult => {
       this.config.instance.dataCenterInfo.metadata = merge(
-        this.config.instance.dataCenterInfo.metadata,
-        metadataResult
+        metadataResult,
+        this.config.instance.dataCenterInfo.metadata
       );
       const useLocal = this.config.eureka.useLocalMetadata;
       const preferIpAddress = this.config.eureka.preferIpAddress;


### PR DESCRIPTION
variable **metadataResult** containing the default values was overwriting all the custom values provided by the user, making the custom values useless.

The issue was fixed by changing the order of the arguments passed to the **merge** function.