### PR TITLE
feat(EurekaClient.js): Allow an independent EUREKA_ENV env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const client = new Eureka({
 });
 ```
 
-The Eureka client searches for the YAML file `eureka-client.yml` in the current working directory. It further searches for environment specific overrides in the environment specific YAML files (e.g. `eureka-client-test.yml`). The environment is typically `development` or `production`, and is determined by the `NODE_ENV` environment variable. The options passed to the constructor overwrite any values that are set in configuration files.
+The Eureka client searches for the YAML file `eureka-client.yml` in the current working directory. It further searches for environment specific overrides in the environment specific YAML files (e.g. `eureka-client-test.yml`). The environment is typically `development` or `production`, and is determined by environment variables in this order: `EUREKA_ENV`, if present, or `NODE_ENV`, if present. Otherwise it defaults to `development`. The options passed to the constructor overwrite any values that are set in configuration files.
 
 You can configure a custom directory to load the configuration files from by specifying a `cwd` option in the object passed to the `Eureka` constructor.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka-js-client",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "description": "A JavaScript implementation the Netflix OSS service registry, Eureka.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -54,7 +54,7 @@ export default class Eureka extends EventEmitter {
 
     // Load up the current working directory and the environment:
     const cwd = config.cwd || process.cwd();
-    const env = process.env.NODE_ENV || 'development';
+    const env = process.env.EUREKA_ENV || process.env.NODE_ENV || 'development';
 
     const filename = config.filename || 'eureka-client';
 


### PR DESCRIPTION
This allows developers to select whatever Eureka config file they need without having to rely on `NODE_ENV`.
For example, we can set `EUREKA_ENV=test`, but keep `NODE_ENV=production` for all the middleware and components in our library.