### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const client = new Eureka({
   // application instance information
   instance: {
     app: 'jqservice',
+    instanceId: 'jqservice',
     hostName: 'localhost',
     ipAddr: '127.0.0.1',
     port: 8080,


### PR DESCRIPTION
`InstanceId` is a required field without which app can not be found by Java Spring cloud ribbon.
But the only documentation did not mention this.

related question: https://stackoverflow.com/questions/50965591/spring-cloud-netflix-eureka-doesnt-find-eureka-js-instances