### PR TITLE
- instanceId is now set from requested metadata if not specified explicitly

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -536,6 +536,9 @@ export default class Eureka extends EventEmitter {
       const metadataIpAddress = metadataResult[useLocal ? 'local-ipv4' : 'public-ipv4'];
       this.config.instance.hostName = preferIpAddress ? metadataIpAddress : metadataHostName;
       this.config.instance.ipAddr = metadataIpAddress;
+      if (!this.config.instance.instanceId && metadataResult['instance-id']) {
+        this.config.instance.instanceId = metadataResult['instance-id'];
+      }
 
       if (this.config.instance.statusPageUrl) {
         const { statusPageUrl } = this.config.instance;


### PR DESCRIPTION
I'm currently trying to integrate a NodeJS App into a Spring Cloud Gateway which usually only handles Java Services registered with Eureka. I noticed, that in order to work correctly the instanceId of the instance i want to register needs to be on par with the instanceId of the dataCenter's metadata.

To solve this, I modified the addInstanceMetadata() function to set the instanceId based on the metadataResult, if no id for the instance was specified manually.