### PR TITLE
Retry 400s

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -606,7 +606,7 @@ export default class Eureka extends EventEmitter {
       // Perform retry if request failed and we have attempts left
       const responseInvalid = response
         && response.statusCode
-        && String(response.statusCode)[0] === '5';
+        && response.statusCode >= 400;
 
       if ((error || responseInvalid) && retryAttempt < this.config.eureka.maxRetries) {
         const nextRetryDelay = this.config.eureka.requestRetryDelay * (retryAttempt + 1);

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -7,6 +7,7 @@ export default {
     registryFetchInterval: 30000,
     maxRetries: 3,
     requestRetryDelay: 500,
+    retryableStatusCodes: "500-599",
     fetchRegistry: true,
     filterUpInstances: true,
     servicePath: '/eureka/v2/apps/',

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -1113,6 +1113,31 @@ describe('Eureka client', () => {
       requestStub.onCall(2).yields(null, { statusCode: 200 }, null);
       client.eurekaRequest({ uri: '/path' }, (error) => {
         expect(error).to.be.null;
+        expect(requestStub).to.be.calledTwice;
+        expect(requestStub.args[0][0]).to.have.property('baseUrl', 'http://serverA');
+        expect(requestStub.args[1][0]).to.have.property('baseUrl', 'http://serverB');
+        done();
+      });
+    });
+    it('should retry next server on configured request failure', (done) => {
+      const overrides = {
+        eureka: {
+          serviceUrls: {
+            default: ['http://serverA', 'http://serverB', 'http://serverC'],
+          },
+          maxRetries: 3,
+          requestRetryDelay: 0,
+          retryableStatusCodes: "400-404,500-504"
+        },
+      };
+      const config = makeConfig(overrides);
+      const client = new Eureka(config);
+      const requestStub = sinon.stub(request, 'get');
+      requestStub.onCall(0).yields(null, { statusCode: 500 }, null);
+      requestStub.onCall(1).yields(null, { statusCode: 400 }, null);
+      requestStub.onCall(2).yields(null, { statusCode: 200 }, null);
+      client.eurekaRequest({ uri: '/path' }, (error) => {
+        expect(error).to.be.null;
         expect(requestStub).to.be.calledThrice;
         expect(requestStub.args[0][0]).to.have.property('baseUrl', 'http://serverA');
         expect(requestStub.args[1][0]).to.have.property('baseUrl', 'http://serverB');

--- a/test/EurekaClient.test.js
+++ b/test/EurekaClient.test.js
@@ -1099,7 +1099,7 @@ describe('Eureka client', () => {
       const overrides = {
         eureka: {
           serviceUrls: {
-            default: ['http://serverA', 'http://serverB'],
+            default: ['http://serverA', 'http://serverB', 'http://serverC'],
           },
           maxRetries: 3,
           requestRetryDelay: 0,
@@ -1109,12 +1109,14 @@ describe('Eureka client', () => {
       const client = new Eureka(config);
       const requestStub = sinon.stub(request, 'get');
       requestStub.onCall(0).yields(null, { statusCode: 500 }, null);
-      requestStub.onCall(1).yields(null, { statusCode: 200 }, null);
+      requestStub.onCall(1).yields(null, { statusCode: 400 }, null);
+      requestStub.onCall(2).yields(null, { statusCode: 200 }, null);
       client.eurekaRequest({ uri: '/path' }, (error) => {
         expect(error).to.be.null;
-        expect(requestStub).to.be.calledTwice;
+        expect(requestStub).to.be.calledThrice;
         expect(requestStub.args[0][0]).to.have.property('baseUrl', 'http://serverA');
         expect(requestStub.args[1][0]).to.have.property('baseUrl', 'http://serverB');
+        expect(requestStub.args[2][0]).to.have.property('baseUrl', 'http://serverC');
         done();
       });
     });


### PR DESCRIPTION
A problem I've been noticing is that occasionally a server in our eureka cluster starts returning a 400 status. We do notice the problem and fix it, however because of the way the retry logic is structured, only 5xx status get retried. The implication of this is that once our bad server starts returning a 400, the eureka client doesn't move on and try the healthy good ones. This make our service(s) unavailable for a period of time until the server is fixed or manually restarted.
I've updated the logic so that all non-200 statuses are considered an error to be retried to help make our services more resilient without manual intervention.