### PR TITLE
refactor: replaced request library as got library

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,7 +5,7 @@ import eslint from 'gulp-eslint';
 import { Instrumenter } from 'babel-istanbul';
 import istanbul from 'gulp-istanbul';
 import env from 'gulp-env';
-import request from 'request';
+import got from 'got';
 import { spawn, exec } from 'child_process';
 
 gulp.task('build', () => (
@@ -59,7 +59,7 @@ function waitForEureka(cb) {
   else if ((+new Date() - startTime) > EUREKA_INIT_TIMEOUT) {
     return cb(new Error('Eureka failed to start before timeout'));
   }
-  request.get({ url: `http://localhost:${DOCKER_PORT}/eureka` }, (err) => {
+  got.get(`http://localhost:${DOCKER_PORT}/eureka`, (err) => {
     if (err) {
       if (err.code === 'ECONNRESET') {
         console.log('Eureka connection not ready. Waiting..'); // eslint-disable-line

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka-js-client",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "A JavaScript implementation the Netflix OSS service registry, Eureka.",
   "main": "lib/index.js",
   "scripts": {
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/jquatier/eureka-js-client",
   "dependencies": {
-    "async": "^2.0.1",
-    "js-yaml": "^3.3.1",
-    "lodash": "^4.13.1",
-    "request": "^2.83.0"
+    "async": "^3.2.0",
+    "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
+    "got": "^11.8.2"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",

--- a/src/AwsMetadata.js
+++ b/src/AwsMetadata.js
@@ -1,4 +1,4 @@
-import request from 'request';
+import got from 'got';
 import async from 'async';
 import Logger from './Logger';
 
@@ -63,24 +63,22 @@ export default class AwsMetadata {
   }
 
   lookupMetadataKey(key, callback) {
-    request.get({
-      url: `http://${this.host}/latest/meta-data/${key}`,
-    }, (error, response, body) => {
-      if (error) {
-        this.logger.error('Error requesting metadata key', error);
-      }
-      callback(null, (error || response.statusCode !== 200) ? null : body);
-    });
+    got.get(`http://${this.host}/latest/meta-data/${key}`,
+     (error, response, body) => {
+       if (error) {
+         this.logger.error('Error requesting metadata key', error);
+       }
+       callback(null, (error || response.statusCode !== 200) ? null : body);
+     });
   }
 
   lookupInstanceIdentity(callback) {
-    request.get({
-      url: `http://${this.host}/latest/dynamic/instance-identity/document`,
-    }, (error, response, body) => {
-      if (error) {
-        this.logger.error('Error requesting instance identity document', error);
-      }
-      callback(null, (error || response.statusCode !== 200) ? null : JSON.parse(body));
-    });
+    got.get(`http://${this.host}/latest/dynamic/instance-identity/document`,
+     (error, response, body) => {
+       if (error) {
+         this.logger.error('Error requesting instance identity document', error);
+       }
+       callback(null, (error || response.statusCode !== 200) ? null : JSON.parse(body));
+     });
   }
 }

--- a/test/AwsMetadata.test.js
+++ b/test/AwsMetadata.test.js
@@ -1,7 +1,8 @@
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import request from 'request';
+// import request from 'request';
+import got from 'got';
 import AwsMetadata from '../src/AwsMetadata';
 
 chai.use(sinonChai);
@@ -14,60 +15,60 @@ describe('AWS Metadata client', () => {
     });
 
     afterEach(() => {
-      request.get.restore();
+      got.get.restore();
     });
 
     it('should call metadata URIs', () => {
-      const requestStub = sinon.stub(request, 'get');
+      const requestStub = sinon.stub(got, 'get');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/ami-id',
-      }).yields(null, { statusCode: 200 }, 'ami-123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/ami-id'
+      ).yields(null, { statusCode: 200 }, 'ami-123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-id',
-      }).yields(null, { statusCode: 200 }, 'i123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-id'
+      ).yields(null, { statusCode: 200 }, 'i123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-type',
-      }).yields(null, { statusCode: 200 }, 'medium');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-type'
+      ).yields(null, { statusCode: 200 }, 'medium');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-ipv4',
-      }).yields(null, { statusCode: 200 }, '1.1.1.1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-ipv4'
+      ).yields(null, { statusCode: 200 }, '1.1.1.1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-hostname',
-      }).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-hostname'
+      ).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone',
-      }).yields(null, { statusCode: 200 }, 'fake-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone'
+      ).yields(null, { statusCode: 200 }, 'fake-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-hostname',
-      }).yields(null, { statusCode: 200 }, 'ec2-127-0-0-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-hostname'
+      ).yields(null, { statusCode: 200 }, 'ec2-127-0-0-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-ipv4',
-      }).yields(null, { statusCode: 200 }, '2.2.2.2');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-ipv4'
+      ).yields(null, { statusCode: 200 }, '2.2.2.2');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/mac',
-      }).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/mac'
+      ).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/dynamic/instance-identity/document',
-      }).yields(null, { statusCode: 200 }, '{"accountId":"123456"}');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/dynamic/instance-identity/document'
+      ).yields(null, { statusCode: 200 }, '{"accountId":"123456"}');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id',
-      }).yields(null, { statusCode: 200 }, 'vpc123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id'
+      ).yields(null, { statusCode: 200 }, 'vpc123');
 
       const fetchCb = sinon.spy();
       client.fetchMetadata(fetchCb);
 
-      expect(request.get).to.have.been.callCount(11);
+      expect(got.get).to.have.been.callCount(11);
 
       expect(fetchCb).to.have.been.calledWithMatch({
         accountId: '123456',
@@ -85,57 +86,57 @@ describe('AWS Metadata client', () => {
     });
 
     it('should call metadata URIs and filter out null and undefined values', () => {
-      const requestStub = sinon.stub(request, 'get');
+      const requestStub = sinon.stub(got, 'get');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/ami-id',
-      }).yields(null, { statusCode: 200 }, 'ami-123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/ami-id'
+      ).yields(null, { statusCode: 200 }, 'ami-123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-id',
-      }).yields(null, { statusCode: 200 }, 'i123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-id'
+      ).yields(null, { statusCode: 200 }, 'i123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-type',
-      }).yields(null, { statusCode: 200 }, 'medium');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-type'
+      ).yields(null, { statusCode: 200 }, 'medium');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-ipv4',
-      }).yields(null, { statusCode: 200 }, '1.1.1.1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-ipv4'
+      ).yields(null, { statusCode: 200 }, '1.1.1.1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-hostname',
-      }).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-hostname'
+      ).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone',
-      }).yields(null, { statusCode: 200 }, 'fake-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone'
+      ).yields(null, { statusCode: 200 }, 'fake-1');
 
       let undef;
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-hostname',
-      }).yields(null, { statusCode: 200 }, undef);
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-hostname'
+      ).yields(null, { statusCode: 200 }, undef);
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-ipv4',
-      }).yields(null, { statusCode: 200 }, null);
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-ipv4'
+      ).yields(null, { statusCode: 200 }, null);
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/mac',
-      }).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/mac'
+      ).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/dynamic/instance-identity/document',
-      }).yields(null, { statusCode: 200 }, '{"accountId":"123456"}');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/dynamic/instance-identity/document'
+      ).yields(null, { statusCode: 200 }, '{"accountId":"123456"}');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id',
-      }).yields(null, { statusCode: 200 }, 'vpc123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id'
+      ).yields(null, { statusCode: 200 }, 'vpc123');
 
       const fetchCb = sinon.spy();
       client.fetchMetadata(fetchCb);
 
-      expect(request.get).to.have.been.callCount(11);
+      expect(got.get).to.have.been.callCount(11);
       expect(fetchCb).to.have.been.calledWithMatch({
         accountId: '123456',
         'ami-id': 'ami-123',
@@ -159,56 +160,56 @@ describe('AWS Metadata client', () => {
     });
 
     it('should call metadata URIs and filter out errored values', () => {
-      const requestStub = sinon.stub(request, 'get');
+      const requestStub = sinon.stub(got, 'get');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/ami-id',
-      }).yields(null, { statusCode: 200 }, 'ami-123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/ami-id'
+      ).yields(null, { statusCode: 200 }, 'ami-123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-id',
-      }).yields(null, { statusCode: 200 }, 'i123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-id'
+      ).yields(null, { statusCode: 200 }, 'i123');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/instance-type',
-      }).yields(null, { statusCode: 200 }, 'medium');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/instance-type'
+      ).yields(null, { statusCode: 200 }, 'medium');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-ipv4',
-      }).yields(null, { statusCode: 200 }, '1.1.1.1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-ipv4'
+      ).yields(null, { statusCode: 200 }, '1.1.1.1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/local-hostname',
-      }).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/local-hostname'
+      ).yields(null, { statusCode: 200 }, 'ip-127-0-0-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone',
-      }).yields(null, { statusCode: 200 }, 'fake-1');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/placement/availability-zone'
+      ).yields(null, { statusCode: 200 }, 'fake-1');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-hostname',
-      }).yields(new Error('fail'));
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-hostname'
+      ).yields(new Error('fail'));
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/public-ipv4',
-      }).yields(new Error('fail'));
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/public-ipv4'
+      ).yields(new Error('fail'));
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/mac',
-      }).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/mac'
+      ).yields(null, { statusCode: 200 }, 'AB:CD:EF:GH:IJ');
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/dynamic/instance-identity/document',
-      }).yields(new Error('fail'));
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/dynamic/instance-identity/document'
+      ).yields(new Error('fail'));
 
-      requestStub.withArgs({
-        url: 'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id',
-      }).yields(null, { statusCode: 200 }, 'vpc123');
+      requestStub.withArgs(
+        'http://127.0.0.1:8888/latest/meta-data/network/interfaces/macs/AB:CD:EF:GH:IJ/vpc-id'
+      ).yields(null, { statusCode: 200 }, 'vpc123');
 
       const fetchCb = sinon.spy();
       client.fetchMetadata(fetchCb);
 
-      expect(request.get).to.have.been.callCount(11);
+      expect(got.get).to.have.been.callCount(11);
       expect(fetchCb).to.have.been.calledWithMatch({
         'ami-id': 'ami-123',
         'availability-zone': 'fake-1',


### PR DESCRIPTION
Hi @jquatier , request library has been deprecated, so I used got library and upgraded dependency version also verified all test cases, Please validate, merge and npm-publish

used yaml.load instead of yaml.safeLoad
//  Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default 