### PR TITLE
Update error message console output for debugging

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -227,7 +227,7 @@ export default class Eureka extends EventEmitter {
         return callback(error);
       }
       return callback(
-        new Error(`eureka registration FAILED: status: ${response.statusCode} body: ${body}`)
+        new Error(`eureka registration FAILED: status: ${response.statusCode} body: ${JSON.stringify(body)}`)
       );
     });
   }


### PR DESCRIPTION
Currently error message is showing as: eureka registration FAILED: status: 400 body: [object Object] After the change it should show as: eureka registration FAILED: status: 400 body: {"error":"cannot parse request body"}

This will help the developer to understand better the error messaged been by the server.